### PR TITLE
Fix Group for file torrc

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -250,7 +250,7 @@ class tor (
     ensure  => $file_ensure,
     mode    => '0644',
     owner   => 'root',
-    group   => '_tor',
+    group   => 'root',
     content => template('tor/torrc.erb'),
     require => Package[$package_name],
     notify  => Service[$service_name],


### PR DESCRIPTION
Hi,
on Fedora 20 i have to change the group torrc file. Is the a specific reason why torrc have the group "_tor"?
